### PR TITLE
feat: edit deployment helm chart

### DIFF
--- a/helm/api-server/templates/deployment.yaml
+++ b/helm/api-server/templates/deployment.yaml
@@ -1,35 +1,45 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: api-server
+ name: api-server
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: api-server
-  template:
-    metadata:
-      labels:
-        app: api-server
-    spec:
-      containers:
-      - name: api-server
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        command: ["python"]
-        args: ["dev_init_db.py"]
-        ports:
-        - containerPort: 8000
-        env:
-        env:
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: db-credentials
-              key: database-url
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: db-credentials
-              key: password
-        resources:
-          {{- toYaml .Values.resources | nindent 10 }}
+ replicas: 1
+ selector:
+   matchLabels:
+     app: api-server
+ template:
+   metadata:
+     labels:
+       app: api-server
+   spec:
+     containers:
+     - name: api-server
+       image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+       command: ["python"]
+       args: ["dev_init_db.py"]
+       ports:
+       - containerPort: 8000
+       env:
+       - name: DATABASE_URL
+         valueFrom:
+           secretKeyRef:
+             name: db-credentials
+             key: database-url
+       - name: KUBERNETES_NAMESPACE
+         valueFrom:
+           fieldRef:
+             fieldPath: metadata.namespace
+       - name: POD_IP
+         valueFrom:
+           fieldRef:
+             fieldPath: status.podIP
+       - name: NODE_NAME
+         valueFrom:
+           fieldRef:
+             fieldPath: spec.nodeName
+       - name: HOSTNAME
+         valueFrom:
+           fieldRef:
+             fieldPath: metadata.name
+       resources:
+         {{- toYaml .Values.resources | nindent 10 }}


### PR DESCRIPTION
## 관련 이슈
- closes #8 

## 변경 사항
Health Check API를 Kubernetes에 배포되는 Application에 걸맞게 수정하였습니다
1. 이제 namespace의 이름을 확인할 수 있습니다.
2. 이제 Pod의 이름과 IP를 확인할 수 있습니다.
3. 이제 데이터베이스의 버전 및 응답 레이턴시를 확인할 수 있습니다.

## 테스트 항목
- [x] Kubernetes cluster 위에 배포된 swagger로 Health check 항목들을 확인하였습니다.
<img width="1334" alt="swagger healthcheck" src="https://github.com/user-attachments/assets/e08bc92f-6b27-44f0-903f-e5db6bd40439">
wagger 확인

- [x] Terminal로 Health check API를 작동시켰습니다.
<img width="982" alt="image" src="https://github.com/user-attachments/assets/4e748d30-9c5c-4412-b40e-0c9063614403">


## 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 새로운 테스트가 추가되었나요?